### PR TITLE
Set the upper version for symphony processor to 4.1.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "laravel",
         "anton",
         "ottosmops",
-        "pdftotext"        
+        "pdftotext"
     ],
     "authors": [
         {
@@ -18,7 +18,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.6.0",
-        "symfony/process": ">=3.0"
+        "symfony/process": ">=3.0 < 4.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0"


### PR DESCRIPTION
This should prevent triggering errors
for creating process instances with
new Process() and passing down string as command
instead of array.

This behaviour is deprecated in 4.2+ of the library.